### PR TITLE
Migrate to prettier flat config

### DIFF
--- a/.prettierrc.json
+++ b/.prettierrc.json
@@ -1,8 +1,0 @@
-{
-  "arrowParens": "avoid",
-  "singleQuote": true,
-  "printWidth": 100,
-  "tabWidth": 2,
-  "trailingComma": "es5",
-  "plugins": ["prettier-plugin-organize-imports"]
-}

--- a/prettier.config.cjs
+++ b/prettier.config.cjs
@@ -1,0 +1,12 @@
+// https://github.com/simonhaenisch/prettier-plugin-organize-imports
+const organizeImports = require('prettier-plugin-organize-imports');
+
+// https://prettier.io/docs/en/configuration.html
+module.exports = {
+  tabWidth: 2,
+  printWidth: 100,
+  singleQuote: true,
+  arrowParens: 'avoid',
+  trailingComma: 'es5',
+  plugins: [organizeImports],
+};


### PR DESCRIPTION
Migration to `prettier` flat config [chore: .prettierrc.json -> prettier.config.cjs](https://github.com/kr4chinin/kr4chinin-advanced-vite-react-spa-template/commit/c28662a6c31f1686c3afd56b8cf10960138a73a2).